### PR TITLE
Fix build-target.sh script for sp530e to return the correct chip type for the build environment

### DIFF
--- a/scripts/build-target.sh
+++ b/scripts/build-target.sh
@@ -128,6 +128,7 @@ detect_chip_from_env() {
   elif [[ "$lower_env" == *"esp32s2"* ]]; then echo "esp32s2"
   elif [[ "$lower_env" == *"esp32h2"* ]]; then echo "esp32h2"
   elif [[ "$lower_env" == *"esp8266"* ]] || [[ "$lower_env" == *"nodemcu"* ]]; then echo "esp8266"
+  elif [[ "$lower_env" == *"sp530e"* ]]; then echo "esp32c3"
   else echo "esp32"
   fi
 }


### PR DESCRIPTION
Since the current way the build-target.sh script detects the chip type relies on the chip name being in the environment name, building the sp530e environment returns a generic esp32 as the chip type instead of the correct esp32c3. Which later leads to the wrong offset for the bootloader address being passed to the command building the merged full image.

This proposed fix adds the sp530e environment name as a separate if-case and returns the correct chip type for this case.

The fix was tested and confirmed with a SP530E controller that after the change now correctly boots to WLED.