### PR TITLE
docs(waveshare): correct stale v16 Ethernet claims, point to v17

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,12 @@ If you remember one thing: type `release` only when you want fireworks on the Re
   - Preserved legacy firmware: `targets/seeed-xiao-esp32s3/v16/assets/legacy/`
 - **Waveshare ESP32-S3-ETH**
   - Canonical env: `targets/waveshare-esp32s3-eth/shared/platformio.env.ini`
-  - Active line notes: `targets/waveshare-esp32s3-eth/v15/notes.md`
+  - `v17` (recommended): WLED `main`/IDF5, native lwIP W5500 — DDP/E1.31/MQTT/web UI all work
+    over Ethernet. Hardware-validated on two boards. `targets/waveshare-esp32s3-eth/v17/notes.md`
+  - `v16`: WLED 16.0.1, W5500 hardware-socket offload — hardware-validated, but Ethernet only
+    carries link-up/DHCP, no WLED application traffic (see v16 notes for why).
+    `targets/waveshare-esp32s3-eth/v16/notes.md`
+  - `v15`: preserved/frozen. `targets/waveshare-esp32s3-eth/v15/notes.md`
 - **SP530E**
   - Shared target assets: `targets/sp530e/shared/`
 
@@ -153,10 +158,15 @@ targets/
       build.default.json    ← fallback manifest when targets/<target>/<version>/build.json is missing
       build.example.json    ← complete manifest example (environment, wled_ref, optional wled_repo)
     v15/
-      notes.md              ← v15 active-line delta notes
+      notes.md              ← v15 line notes (preserved/frozen)
       assets/
         README.md           ← no preserved legacy firmware currently tracked
-    v16/                    ← future placeholder only
+    v16/
+      notes.md              ← v16 line notes: WLED 16.0.1, W5500 hardware-socket offload
+      patches/, lib/        ← Ethernet_Generic driver patch + vendored library
+    v17/
+      notes.md              ← v17 line notes: WLED main/IDF5, native lwIP W5500 (recommended)
+      patches/, lib/        ← native ETH_PHY_W5500 patch + vendored NeoPixelBus (RMT fix)
 platformio.ini              ← generic WLED base (root = upstream defaults, not target-specific)
 logs/
   <target>/<version>/

--- a/targets/waveshare-esp32s3-eth/README.md
+++ b/targets/waveshare-esp32s3-eth/README.md
@@ -29,8 +29,21 @@ esptool.py --chip esp32s3 write_flash 0x0000 <your-file>.full.bin
 - Wrong network behavior or missing Ethernet: verify you flashed the Waveshare target build.
 - OTA failures: flash `.full.bin` over UART and retry setup.
 
+## Which line should I use?
+
+This board has three build lines. If you need DDP/E1.31/MQTT or the web UI to work over the
+Ethernet port, **use v17** — on v16, Ethernet only proves link-up/DHCP and carries no WLED
+application traffic (see v16 notes for why).
+
+| Line | WLED base | Ethernet model | DDP/E1.31/MQTT/web UI over Ethernet? | Status |
+|---|---|---|---|---|
+| **v17 (recommended)** | `main` / IDF5 / Core 3.3.8 | native lwIP (`ETH_PHY_W5500`) | Yes | Hardware-validated on two boards |
+| v16 | 16.0.1 | W5500 hardware-socket offload | No — Ethernet only carries link-up/DHCP | Hardware-validated |
+| v15 | 0.15.x | (preserved/frozen) | — | Preserved, not actively developed |
+
 ## More target details
 
-- v16 active line notes (WLED 16.0.1, W5500 hardware-socket Ethernet): [targets/waveshare-esp32s3-eth/v16/notes.md](v16/notes.md) — not yet validated on physical hardware, compiles clean.
+- v17 line notes (WLED `main`, native lwIP W5500 — recommended): [targets/waveshare-esp32s3-eth/v17/notes.md](v17/notes.md)
+- v16 line notes (WLED 16.0.1, W5500 hardware-socket Ethernet): [targets/waveshare-esp32s3-eth/v16/notes.md](v16/notes.md) — hardware-validated; see notes for the Ethernet application-traffic limitation.
 - v15 line notes (WLED 0.15.x, preserved/frozen): [targets/waveshare-esp32s3-eth/v15/notes.md](v15/notes.md)
-- Shared target config (v15 line only — v16 has its own env fragment, see v16/notes.md): [targets/waveshare-esp32s3-eth/shared](shared)
+- Shared target config (v15 line only — v16/v17 each have their own env fragment, see their notes.md): [targets/waveshare-esp32s3-eth/shared](shared)

--- a/targets/waveshare-esp32s3-eth/v16/notes.md
+++ b/targets/waveshare-esp32s3-eth/v16/notes.md
@@ -3,19 +3,34 @@
 W5500 Ethernet ported forward from the validated `waveshare-esp32s3-eth-v15.1` branch to
 WLED `v16.0.1`.
 
+> **Need DDP/E1.31/MQTT or the web UI to work over Ethernet?** Use `../v17/` instead. This
+> line's W5500 driver is a separate hardware-socket stack that no WLED application traffic
+> actually flows through — see "Confirmed limitation" below.
+
 ## Hardware validation status
 
-**Verified on a Waveshare ESP32-S3-ETH:**
+**Verified on physical Waveshare ESP32-S3-ETH hardware:**
 - Boots cleanly; serves the `WLED-ETH-Config` AP, accepts WiFi credentials, connects over WiFi.
 - 3MB app partitions; firmware occupies ~39% of the app slot.
+- Correct DIO flash-mode header — no boot loop (see "Flash mode" below for what breaks this).
 - **W5500 Ethernet comes up**: chip detected over SPI (`hardwareStatus=3`), link detected
   (`linkStatus=1`), DHCP lease obtained.
 - WiFi and Ethernet run simultaneously with **distinct IPs**, both shown in the info panel.
+- GPIO0 is usable as a normal LED data pin (was previously, incorrectly, reserved by the
+  settings UI — fixed, see commit history).
 
-Still **unverified on hardware**:
-- Whether realtime protocols (DDP/E1.31/Art-Net) and MQTT actually traverse the W5500 —
-  see "Known limitation" below. This is the significant open question.
-- OTA behavior over a long period / repeated updates on the 3MB layout.
+**Confirmed limitation, not a gap in testing — tested and reproduced twice:**
+- **Realtime protocols (DDP/E1.31/Art-Net) do NOT traverse the W5500 on this line.** This
+  isn't "unverified," it's a tested negative result. AsyncUDP/lwIP is what WLED's DDP/E1.31
+  handlers bind to, and this line's W5500 driver is deliberately a separate, parallel hardware
+  socket stack (see "Architecture" below) that nothing in WLED's protocol handlers talks to.
+  Sending DDP to this firmware's Ethernet IP does not reach the strip. Practically, the
+  Ethernet interface on this line only proves link-up/DHCP at the driver level — no WLED
+  application traffic (web UI, DDP, MQTT) actually flows over it; only WiFi does.
+  **If you need DDP/E1.31/MQTT/web UI over Ethernet, use the `v17` line instead** — it wires
+  W5500 up as a real lwIP interface (`ETH_PHY_W5500`) instead of a parallel hardware-socket
+  stack, so all of that works over Ethernet automatically. See `../v17/notes.md`.
+- OTA behavior over a long period / repeated updates on the 3MB layout — still untested.
 
 ### Debugging notes earned the hard way
 
@@ -64,7 +79,12 @@ Ground truth for this board, read from the image header of the working v0.15.1 f
 
 ## Active line status
 
-- **Active line for this target:** `v16`
+- **This line (`v16`) is hardware-validated but architecturally limited** — see "Confirmed
+  limitation" above. It's kept for reference and for anyone who specifically wants the
+  hardware-socket TCP/IP offload and doesn't need realtime protocols/web UI over Ethernet.
+- **`v17` is the recommended line for this board** (WLED `main`, IDF5/Core3, native lwIP
+  `ETH_PHY_W5500`) — DDP/E1.31/MQTT and the web UI/OTA all work over Ethernet there, validated
+  on two physical boards. See `../v17/notes.md`.
 - WLED ref: `v16.0.1` (see `build.json`; there is no `0.16.1` — WLED dropped the `0.` prefix and
   moved from `Aircoookie/WLED` to `wled/WLED` between the 0.15.x and 16.x lines)
 - Canonical PlatformIO environment: `waveshare_esp32s3_eth`
@@ -128,7 +148,7 @@ current tooling). Changing `shared/` risks changing what "v15" means without bei
 verify v15 still builds the same way. This port's real, verified, compiling code lives entirely
 under this `v16/` directory (`patches/`, `lib/`, `platformio.env.ini`) instead.
 
-## Architecture: why WiFi + Ethernet run simultaneously (kept from the v15.1 port)
+## Architecture: why WiFi + Ethernet run simultaneously, and why Ethernet only proves link-up here
 
 The W5500's actual differentiating hardware is its onboard hardwired TCP/IP stack (WIZnet's own
 silicon socket engine) — using it means AsyncTCP (which is hardwired to ESP32's lwIP, not a
@@ -137,14 +157,21 @@ in ESP-IDF's native MACRAW mode via `ETH_PHY_W5500` — gets lwIP/AsyncTCP compa
 but per Espressif's own driver docs, explicitly **does not use the W5500's hardware TCP/IP
 engine at all**; the chip becomes a bare MAC/PHY bridge and the ESP32 CPU does all protocol
 processing in software, same as any RMII PHY. This port deliberately keeps the hardware-socket
-approach (real offload) and accepts the WiFi/Ethernet split as the necessary consequence:
+approach (real offload) — but the split that results is less useful than it may sound:
 
-- **WiFi**: Web UI, WebSockets, HTTP/JSON API, OTA (whatever needs AsyncTCP/lwIP)
-- **W5500 (hardware sockets)**: realtime UDP LED protocols (E1.31/Art-Net/DDP), MQTT
+- **WiFi**: Web UI, WebSockets, HTTP/JSON API, OTA, and DDP/E1.31/MQTT (everything, because
+  everything in WLED runs over AsyncTCP/lwIP)
+- **W5500 (hardware sockets)**: link-up + DHCP only. The design intent was for realtime UDP LED
+  protocols (E1.31/Art-Net/DDP) and MQTT to run over the W5500's own hardware sockets instead of
+  lwIP — but no protocol handler in WLED was ever wired to talk to that hardware-socket API, and
+  confirmed by testing, none of them do. The Ethernet interface comes up and gets an IP, but
+  carries no WLED application traffic at all.
 
-A single-interface, Ethernet-only design is possible but requires replacing WLED's web/socket
-layer with one built on the W5500's own hardware socket API — a genuinely large, standing fork
-of WLED's networking core (not a target overlay), scoped separately if pursued.
+Making the hardware-socket approach actually carry application traffic would require replacing
+WLED's web/socket layer *and* its realtime-protocol receivers with code built on the W5500's own
+hardware socket API — a genuinely large, standing fork of WLED's networking core (not a target
+overlay), not attempted here. **`v17` sidesteps this entirely** by using `ETH_PHY_W5500` (lwIP)
+instead, at the cost of losing the hardware TCP/IP offload itself — see `../v17/notes.md`.
 
 ## Hardware / pin configuration
 
@@ -185,15 +212,17 @@ files specifically when moving this port to a 17.x/nightly base — don't assume
 
 ## What's not done
 
-- **No physical hardware validation.** DHCP lease acquisition, hot-plug detection, and dual
-  WiFi+Ethernet runtime behavior are unverified beyond compilation.
+- **Hot-plug detection** (unplugging/replugging the Ethernet cable at runtime) is unverified.
+- OTA behavior over a long period / repeated updates on the 3MB layout — untested.
 - **Root `platformio.ini`'s `[env:waveshare_esp32s3_eth]` compatibility copy is not wired to
   this driver** — it still only carries build flags against this repo's own vendored `wled00/`,
   which does not have this patch applied. Use `scripts/build-target.sh` (below), not a direct
   root-level `pio run`, until/unless that's addressed separately.
 - **Option 2 (fully hardware-socket, no WiFi needed at all)** — replacing WLED's web/socket
   layer to run entirely on the W5500's hardware sockets — was scoped in discussion but not
-  started. It's a standing fork of WLED's networking core, not a target overlay.
+  started. It's a standing fork of WLED's networking core, not a target overlay. Given `v17`
+  now solves the same problem (application traffic over Ethernet) a different way, this is
+  unlikely to be worth pursuing.
 
 ## Building
 


### PR DESCRIPTION
v16/notes.md predated hardware validation and the DDP finding, so it presented things as "unverified" that are now confirmed: DDP/E1.31/MQTT do not traverse the W5500 on v16 (nothing in WLED's protocol handlers talks to the hardware- socket API it uses), and it still said "no physical hardware validation" after the board had been validated. Ethernet on v16 only proves link-up/DHCP - no WLED application traffic flows over it, only WiFi does.

Updates v16/notes.md's validation status, architecture section, and "what's not done" list to state this plainly instead of as an open question, and points readers needing DDP/E1.31/MQTT/web UI over Ethernet at v17. Also updates the root readme.md and the target's user-facing README to list all three lines (v15/v16/v17) instead of stale v15-only/v16-placeholder text.


Claude-Session: https://claude.ai/code/session_017AKR6QHykqZRW9sapQyFFo