### PR TITLE
v17: fix skip-pixel crash on I2S/LCD buses; correct DATA_PINS to matc…

### DIFF
--- a/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/WLED_PATCH_NOTES.md
+++ b/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/WLED_PATCH_NOTES.md
@@ -27,9 +27,28 @@ Patched in `src/internal/methods/ESP/ESP32/NeoEsp32RmtXMethod.h` (search `DIAG/F
     (and a one-line success confirmation), so a future starvation/allocation failure is visible
     in the boot log instead of manifesting as a silent, permanent hang somewhere else.
 
-No other changes. Re-verify this patch is still needed before bumping the vendored commit -
-check whether upstream `Makuna/NeoPixelBus` has since fixed the return-code handling or changed
-`mem_block_symbols` itself.
+Also patched in `src/internal/methods/ESP/ESP32/NeoEsp32LcdXMethod.h` (S3's LCD/I2S-parallel
+driver) and `src/internal/methods/ESP/ESP32/Core_2_x/NeoEsp32I2sXMethod.h` (classic ESP32/S2's
+real-I2S driver) - search `DIAG/FIX` in both:
 
-See `../../notes.md` for the full investigation (symptom, how the removeAll() hang was
-root-caused down to this exact line, and how it was validated on hardware).
+- `_data` (the method's own pixel-buffer pointer, separate from `NeoPixelBus<>`'s constructor)
+  was never initialized in either class's constructor - only ever set inside `Initialize()`,
+  which WLED calls later via `begin()`, not at construction time. If a bus object is destroyed
+  before `Initialize()` ever ran on it, the destructor still unconditionally calls `free(_data)`
+  on whatever garbage was sitting in that pointer - a crash inside `free()`/`heap_caps_free()`
+  on a bogus, non-null address.
+  - Fixed: `_data(nullptr)` added to both constructors' initializer lists, so an un-Initialize()'d
+    bus's destructor calls `free(nullptr)` - a safe no-op - instead of freeing garbage. Also
+    added a one-line log on that path so it's visible rather than silent.
+  - Note: the actual crash this was chasing (see `../../notes.md`) turned out to have a second,
+    primary cause in WLED's own `bus_manager.cpp` (writing sacrificial/skipped pixels in the
+    `BusDigital` constructor, before `begin()`/`Initialize()` ever ran - fixed separately, not
+    in this vendored copy). This `_data(nullptr)` fix is still worth keeping as a general safety
+    net against the same class of bug from any other call path.
+
+No other changes. Re-verify these patches are still needed before bumping the vendored commit -
+check whether upstream `Makuna/NeoPixelBus` has since fixed the return-code handling, changed
+`mem_block_symbols`, or initialized `_data` itself.
+
+See `../../notes.md` for the full investigation (symptoms, root causes, and how both were
+validated on hardware).

--- a/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/src/internal/methods/ESP/ESP32/Core_2_x/NeoEsp32I2sXMethod.h
+++ b/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/src/internal/methods/ESP/ESP32/Core_2_x/NeoEsp32I2sXMethod.h
@@ -794,8 +794,11 @@ public:
     NeoEsp32I2sXMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizeData(pixelCount * elementSize + settingsSize),
         _pin(pin),
-        _bus()
+        _bus(),
+        _data(nullptr)
     {
+        // DIAG/FIX: same uninitialized-_data issue fixed in NeoEsp32LcdXMethod.h (S3's
+        // equivalent) - see that file's WLED_PATCH_NOTES.md / comment for the full explanation.
         _bus.RegisterNewMuxBus(_sizeData + T_SPEED::ResetTimeUs / T_SPEED::ByteSendTimeUs(T_SPEED::BitSendTimeNs));
     }
 

--- a/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/src/internal/methods/ESP/ESP32/NeoEsp32LcdXMethod.h
+++ b/targets/waveshare-esp32s3-eth/v17/lib/NeoPixelBus/src/internal/methods/ESP/ESP32/NeoEsp32LcdXMethod.h
@@ -614,14 +614,25 @@ public:
     NeoEsp32LcdXMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizeData(pixelCount * elementSize + settingsSize),
         _pin(pin),
-        _bus()
+        _bus(),
+        _data(nullptr)
     {
+        // DIAG/FIX: _data was never initialized here - only ever set inside Initialize(),
+        // which is called separately from begin() after construction. If a bus object is
+        // destroyed before Initialize() ever ran (e.g. WLED's boot-time bus-creation loop
+        // breaks early on an out-of-range/invalid bus, leaving every later bus un-begin()'d),
+        // the destructor below still unconditionally free()s whatever garbage was sitting in
+        // this pointer - a crash inside free()/heap_caps_free() on a bogus, non-null address.
+        // Explicitly initializing to nullptr makes that free(nullptr) a safe no-op instead.
         size_t numResetBytes = T_SPEED::ResetTimeUs / T_SPEED::ByteSendTimeUs(T_SPEED::BitSendTimeNs);
-        _bus.RegisterNewMuxBus(_sizeData + numResetBytes);        
+        _bus.RegisterNewMuxBus(_sizeData + numResetBytes);
     }
 
     ~NeoEsp32LcdXMethodBase()
     {
+        if (_data == nullptr) {
+            Serial.printf("DBG LcdX destructor: pin=%u never Initialize()'d (data=null) - free(nullptr) is a safe no-op\n", _pin);
+        }
         while (!_bus.IsWriteDone())
         {
             yield();

--- a/targets/waveshare-esp32s3-eth/v17/notes.md
+++ b/targets/waveshare-esp32s3-eth/v17/notes.md
@@ -10,8 +10,9 @@ Validated on **two** physical Waveshare ESP32-S3-ETH boards:
 - xLights → DDP over WiFi: pass
 - Web UI over Ethernet: pass
 - Web UI over WiFi: pass
-- Live LED-hardware-settings changes (add/remove/reconfigure buses at runtime, no reboot)
-  over both Ethernet and WiFi: pass
+- Live LED-hardware-settings changes (add/remove/reconfigure buses at runtime, no reboot,
+  including "skip first N LEDs" on both RMT- and I2S/LCD-driven buses) over both Ethernet
+  and WiFi: pass
 
 Not yet tested: MQTT, and a few other minor items — treat those as open until confirmed.
 
@@ -45,19 +46,20 @@ turns into a build failure.
   `#error`s out on chips without `CONFIG_ETH_USE_ESP32_EMAC`, which includes the S3), a deferred
   `handleW5500()` in `wled.cpp`'s `loop()` (see below for why `ETH.begin()` can't run during
   early boot), reserved-pin reporting in `xml.cpp`, and dual WiFi+Ethernet IP display in the
-  info panel (`json.cpp` / `data/index.js`). Also includes the `bus_manager.cpp` fix described
-  below (not Ethernet-specific, but part of the same patch since both were developed together).
+  info panel (`json.cpp` / `data/index.js`). Also includes the `bus_manager.cpp` fixes described
+  below (not Ethernet-specific, but part of the same patch since all were developed together).
 - `lib/NeoPixelBus/` — vendored, patched copy of the exact NeoPixelBus commit WLED main's
-  `[esp32_idf_V5]` env already pins. See `lib/NeoPixelBus/WLED_PATCH_NOTES.md` for the fix
-  itself (RMT channel memory-block starvation on ESP32-S3, see below).
+  `[esp32_idf_V5]` env already pins. See `lib/NeoPixelBus/WLED_PATCH_NOTES.md` for the fixes
+  themselves (RMT channel memory-block starvation, and an uninitialized pixel-buffer pointer —
+  both on ESP32-S3, see below).
 - `build.json` — `wled_ref: main`.
 - `platformio.env.ini` — the `[env:waveshare_esp32s3_eth_v5]` fragment.
 
-## Two bugs found and fixed along the way
+## Three bugs found and fixed along the way
 
-Both were found while chasing "LED hardware settings silently don't save" — which turned out to
-be a real WLED-main/Core3.x bug, **not Ethernet/W5500-specific** (independently reproduced on a
-SEEED ESP32-S3 board with no Ethernet at all).
+The first two were found while chasing "LED hardware settings silently don't save" — which
+turned out to be a real WLED-main/Core3.x bug, **not Ethernet/W5500-specific** (independently
+reproduced on a SEEED ESP32-S3 board with no Ethernet at all).
 
 ### 1. `network.cpp` null-pointer-constant comparison (Ethernet-specific)
 
@@ -87,6 +89,33 @@ the above: the wait is now bounded (~3s) with a per-bus diagnostic dump on timeo
 unconditional infinite spin, so any *future* stuck-bus condition (from any cause) can no longer
 hang a save forever — it'll log which bus/type/pin is stuck and proceed anyway.
 
+### 3. Sacrificial-pixel write before buffer allocation (a WLED bug, exposed by the I2S/LCD driver)
+
+Symptom: setting "skip first N LEDs" on an **I2S/LCD-driven** bus (not RMT — a board with only
+RMT-driven buses, i.e. 4 or fewer digital buses, did not reproduce this) and saving crashed
+immediately (`Guru Meditation Error`, `StoreProhibited`, `EXCVADDR=0x0`) during the very next
+boot's bus creation — not even during the save itself, since the poisoned config gets replayed
+on every subsequent boot until fixed or reverted (this looked like a "bricked" board; it wasn't
+— restoring the auto-saved `/bkp.cfg.json` backup recovers it).
+
+Root-caused via exact `addr2line` resolution (LTO temporarily disabled for the diagnostic build)
+of the crash backtrace to `BusDigital::BusDigital(const BusConfig&)` in `bus_manager.cpp`: the
+"paint sacrificial/skipped pixels black" fix for wled#4759 called `PolyBus::setPixelColor()`
+directly inside the bus constructor, immediately after `PolyBus::create()` — before
+`bus->begin()` (called later, from `WS2812FX::finalizeInit()`) ever runs. For RMT-driven buses
+this happens to be harmless, because `NeoEsp32RmtMethodBase`'s pixel buffer is malloc'd
+unconditionally in its constructor. For I2S/LCD-driven buses it is not: `NeoEsp32LcdXMethodBase`
+(and the classic-ESP32 `NeoEsp32I2sXMethodBase`) only allocate their pixel buffer inside
+`Initialize()`, which is called from `begin()` — so writing a pixel color before `begin()` wrote
+through a garbage/uninitialized pointer.
+
+Fixed by moving the sacrificial-pixel blackout out of `BusDigital`'s constructor and into
+`BusDigital::begin()`, after `PolyBus::begin()` (which allocates the buffer) has run. Also
+added `_data(nullptr)` to both NeoPixelBus method constructors in the vendored copy as a general
+safety net (see `lib/NeoPixelBus/WLED_PATCH_NOTES.md`) — not the primary fix, but it means an
+un-`Initialize()`'d bus's destructor now does a safe `free(nullptr)` instead of freeing garbage,
+for any other call path that might hit the same gap in the future.
+
 ## Pin configuration
 
 Same physical pins as v16 (`MISO=12 MOSI=11 SCLK=13 CS=14 INT=10 RST=9`), confirmed against the
@@ -100,10 +129,14 @@ this board and clear of the W5500 SPI pins, SD card, and USB.
 - MQTT not yet tested (see validation status above).
 - Diagnostic `DEBUG_PRINT`/`Serial.printf` instrumentation from the investigation is still
   present (`set.cpp`, `wled.cpp`'s `entering finalizeInit`/`configNeedsWrite` lines,
-  `bus_manager.cpp`'s bounded-wait diagnostic dump, and the RMT init ok/FAILED logging in the
-  vendored NeoPixelBus). All are low-frequency/event-driven, not spam, and only emit under
-  `WLED_DEBUG`. Left in deliberately for now since they're cheap insurance if anything else
-  surfaces; strip if/when confidence is high enough to not need them.
+  `bus_manager.cpp`'s bounded-wait diagnostic dump and pre-teardown bus manifest, and the RMT
+  init ok/FAILED + LCD-destructor-null logging in the vendored NeoPixelBus). All are
+  low-frequency/event-driven, not spam, and only emit under `WLED_DEBUG`. Left in deliberately
+  for now since they're cheap insurance if anything else surfaces; strip if/when confidence is
+  high enough to not need them.
+- LTO is currently disabled on this env (`build_unflags` in `platformio.env.ini`) so any future
+  crash backtrace resolves to an exact file:line via `addr2line` instead of collapsing to the
+  enclosing function. Costs a bit of flash size/performance; re-enable once confidence is high.
 - This target is deliberately scoped to the Waveshare board only, not sp530e/seeed-xiao.
 
 ## Building

--- a/targets/waveshare-esp32s3-eth/v17/patches/0001-w5500-native-lwip-ethernet.patch
+++ b/targets/waveshare-esp32s3-eth/v17/patches/0001-w5500-native-lwip-ethernet.patch
@@ -1,8 +1,39 @@
 diff --git a/wled00/bus_manager.cpp b/wled00/bus_manager.cpp
-index f8cacc7..b17b208 100644
+index f8cacc7..0e4322f 100644
 --- a/wled00/bus_manager.cpp
 +++ b/wled00/bus_manager.cpp
-@@ -1346,7 +1346,32 @@ uint8_t BusManager::getI(uint8_t busType, const uint8_t* pins, uint8_t driverPre
+@@ -160,11 +160,9 @@ BusDigital::BusDigital(const BusConfig &bc)
+   if (bc.type == TYPE_WS2812_1CH_X3) lenToCreate = NUM_ICS_WS2812_1CH_3X(bc.count); // only needs a third of "RGB" LEDs for NeoPixelBus
+   _busPtr = PolyBus::create(_iType, _pins, lenToCreate + _skip);
+   _valid = (_busPtr != nullptr) && bc.count > 0;
+-  // fix for wled#4759
+-  if (_valid) for (unsigned i = 0; i < _skip; i++) {
+-    PolyBus::setPixelColor(_busPtr, _iType, i, 0, COL_ORDER_GRB); // set sacrificial pixels to black (CO does not matter here)
+-  }
+-  else {
++  // fix for wled#4759: sacrificial (skipped) pixels are painted black in begin(), not here -
++  // see begin() for why (this pointer isn't safe to write through until after PolyBus::begin()).
++  if (!_valid) {
+     cleanup();
+   }
+   DEBUGBUS_PRINTF_P(PSTR("Bus len:%u, type:%u (RGB:%d, W:%d, CCT:%d), pins:%u,%u [itype:%u, driver:%s] mA=%d/%d %s\n"),
+@@ -380,6 +378,15 @@ bool BusDigital::isI2S() {
+ void BusDigital::begin() {
+   if (!_valid) return;
+   PolyBus::begin(_busPtr, _iType, _pins, _frequencykHz);
++  // fix for wled#4759: set sacrificial (skipped) pixels to black. Must happen after
++  // PolyBus::begin() (which calls the underlying NeoPixelBus method's Initialize()), not in
++  // the constructor: some methods (e.g. ESP32-S3's LCD/I2S-parallel driver) lazily allocate
++  // their pixel buffer inside Initialize() rather than their constructor, so writing pixels
++  // before begin() writes through a null pointer - a hard crash (StoreProhibited), reproduced
++  // via "skip first N LEDs" on an I2S/LCD-driven bus.
++  for (unsigned i = 0; i < _skip; i++) {
++    PolyBus::setPixelColor(_busPtr, _iType, i, 0, COL_ORDER_GRB); // set sacrificial pixels to black (CO does not matter here)
++  }
+ }
+ 
+ void BusDigital::cleanup() {
+@@ -1346,8 +1353,45 @@ uint8_t BusManager::getI(uint8_t busType, const uint8_t* pins, uint8_t driverPre
  void BusManager::removeAll() {
    DEBUGBUS_PRINTLN(F("Removing all."));
    //prevents crashes due to deleting busses while in use.
@@ -33,9 +64,22 @@ index f8cacc7..b17b208 100644
 +      yield();
 +    }
 +  }
++  // DIAG: manifest of every bus about to be destroyed, so a crash during busses.clear()
++  // (destructor chain) can be correlated with which specific bus/config triggered it.
++  DEBUG_PRINTLN(F("DBG removeAll: about to destroy busses:"));
++  for (size_t i = 0; i < busses.size(); i++) {
++    Bus *b = busses[i].get();
++    uint8_t pins[5] = {255,255,255,255,255};
++    b->getPins(pins);
++    DEBUG_PRINTF_P(PSTR("DBG   bus[%u] type=%u pin0=%u start=%u len=%u skip=%u isOk=%d isDigital=%d\n"),
++                   (unsigned)i, (unsigned)b->getType(), (unsigned)pins[0], (unsigned)b->getStart(),
++                   (unsigned)b->getLength(), (unsigned)b->skippedLeds(), (int)b->isOk(), (int)b->isDigital());
++  }
    busses.clear();
++  DEBUG_PRINTLN(F("DBG removeAll: busses.clear() completed without crashing."));
    #ifndef ESP8266
    // Reset channel tracking for fresh allocation
+   PolyBus::resetChannelTracking();
 diff --git a/wled00/const.h b/wled00/const.h
 index 00a6b4d..390a92d 100644
 --- a/wled00/const.h

--- a/targets/waveshare-esp32s3-eth/v17/platformio.env.ini
+++ b/targets/waveshare-esp32s3-eth/v17/platformio.env.ini
@@ -44,12 +44,15 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags}
   -D WLED_AP_SSID=\"WLED-ETH-Config\"
   -D WLED_AP_PASS=\"\"
   -D LEDPIN=-1
-  -D DATA_PINS=18,17,16,15,3,2,1,21
-  ;; ^ GPIO0 replaced by GPIO21 and moved to the END of the order (reversed vs. v16's
-  ;; 0,1,2,3,15,16,17,18). GPIO0 is an ESP32-S3 strapping pin that also shares the board's BOOT
-  ;; button, and it is the pin WLED's settings UI is most likely to contest; GPIO21 is free on
-  ;; this board (header pin 35) and clear of the W5500 SPI pins (9-14), the SD card (4-7) and
-  ;; USB (19/20).
+  -D DATA_PINS=17,16,18,15,3,2,1,0
+  ;; ^ Matches the physical board's actual LED header wiring, left to right. GPIO0 IS used here
+  ;; (not GPIO21) - a GPIO21 hardware revision was discussed as a way to dodge GPIO0's
+  ;; strapping-pin/BOOT-button caveat, but that revision does not exist yet (not fabbed) - do
+  ;; not substitute GPIO21 until/unless that board revision is actually built and confirmed.
+  ;; GPIO0's UI-reservation issue (WLED's settings page previously rejecting it outright) is
+  ;; already fixed - see the v16 commit "Stop reserving GPIO0 and the RMII pins when W5500 is
+  ;; selected" - but the physical BOOT-button-contention caveat while GPIO0 is actively driving
+  ;; LED data (see v16/notes.md's "GPIO caveats") still applies and is not fully characterized.
   -D AUDIOPIN=4 -D I2S_SDPIN=4 -D I2S_WSPIN=-1 -D I2S_CKPIN=-1 -D SR_DMTYPE=1
   -D BTNPIN=-1 -D RLYPIN=-1 -D IRPIN=-1
 custom_usermods = audioreactive
@@ -65,4 +68,8 @@ custom_merge_flash_mode = dio
 ;; platformio.env.ini for the full explanation (bootloader mode vs. merged-image header mode;
 ;; this board's flash requires a DIO-header image or it boot-loops in ROM before any
 ;; application code runs). Do not "simplify" these to a single value.
+build_unflags = -flto -flto=auto -flto=thin
+;; ^ diagnostic build: disable LTO so addr2line resolves crash backtraces to exact file:line
+;; instead of collapsing to the enclosing function. Re-enable once confidence is high (see
+;; notes.md "What's not done").
 monitor_filters = esp32_exception_decoder


### PR DESCRIPTION
…h hardware

Two independent fixes plus a config correction, all found while chasing a "skip first N LEDs" crash on I2S/LCD-driven buses.

Root cause (bus_manager.cpp): the wled#4759 fix that paints sacrificial (skipped) pixels black ran inside BusDigital's constructor, immediately after PolyBus::create() - before begin()/Initialize() ever runs. NeoPixelBus's RMT method allocates its buffer in its constructor (harmless), but the I2S/LCD method only allocates it inside Initialize() (called from begin()), so writing a pixel color before begin() wrote through a garbage pointer - a StoreProhibited crash at boot on every subsequent boot until the config was reverted (looked like a bricked board; recoverable via the auto-saved /bkp.cfg.json). Fixed by moving the blackout loop into BusDigital::begin(), after the buffer is guaranteed to exist. Root-caused via exact addr2line resolution (LTO temporarily disabled on this env for future crash decoding).

Also added _data(nullptr) to both vendored NeoPixelBus method constructors (LCD and classic-I2S) as a general safety net: an un-Initialize()'d bus's destructor now does a safe free(nullptr) instead of freeing garbage, for any other call path that might hit the same gap.

Also corrects DATA_PINS: the previous GPIO0->GPIO21 substitution assumed a board revision that was never fabricated. The physical board in hand wires GPIO0, so DATA_PINS is now 17,16,18,15,3,2,1,0 - the board's actual left-to-right header order - not the reversed/substituted list from before.

Validated on hardware: skip=1 on an I2S-driven bus now saves cleanly with no crash, on the corrected pin mapping.


Claude-Session: https://claude.ai/code/session_017AKR6QHykqZRW9sapQyFFo